### PR TITLE
Fix language files and add break-words to media name

### DIFF
--- a/resources/lang/ar/messages.php
+++ b/resources/lang/ar/messages.php
@@ -26,6 +26,8 @@ return [
             'image' => 'الصورة',
             'model' => 'النموذج',
             'collection_name' => 'اسم المجموعة',
+            'size' => 'الججم',
+            'order_column' => 'عمود الترتيب',
         ],
         'actions' => [
             'sub_folder'=> [

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -26,6 +26,8 @@ return [
             'image' => 'Image',
             'model' => 'Model',
             'collection_name' => 'Collection Name',
+            'size' => 'Size',
+            'order_column' => 'Order Column',
         ],
         'actions' => [
             'sub_folder'=> [

--- a/resources/views/pages/media.blade.php
+++ b/resources/views/pages/media.blade.php
@@ -50,7 +50,7 @@
                         <div>
                             <div class="flex flex-col justify-between border-t dark:border-gray-700 p-4">
                                 <div>
-                                    <h1 class="font-bold">{{ $item->hasCustomProperty('title') ? $item->getCustomProperty('title') : $item->name }}</h1>
+                                    <h1 class="font-bold break-words">{{ $item->hasCustomProperty('title') ? $item->getCustomProperty('title') : $item->name }}</h1>
                                 </div>
 
                                 @if($item->hasCustomProperty('description'))


### PR DESCRIPTION
### Description

This pull request includes the following changes:

1. **Add `break-words` Class for Name Wrapping:**
   - Added the `break-words` class to ensure that long media names wrap appropriately in the user interface.

2. **Add Missing Translation Files:**
   - Included the missing translation strings to ensure full localization support across the application.

### Screenshots

**Name Wrapping with `break-words` Class:**

![fix-2024-07-22_11-40](https://github.com/user-attachments/assets/0cd69949-d84a-4f6b-87d5-e2db97577d55)

![fixed2024-07-22_11-41](https://github.com/user-attachments/assets/bdf46ab9-8e92-4470-b229-aa8fbd3bfecf)
