### PR TITLE
Refactor vendor publish and Artisan commands to prevent errors

### DIFF
--- a/src/Console/FilamentMediaManagerInstall.php
+++ b/src/Console/FilamentMediaManagerInstall.php
@@ -37,9 +37,15 @@ class FilamentMediaManagerInstall extends Command
     public function handle()
     {
         $this->info('Publish Vendor Assets');
-        $this->artisanCommand(['vendor:publish --tag="medialibrary-migrations"']);
-        $this->artisanCommand(["migrate"]);
-        $this->artisanCommand(["optimize:clear"]);
+
+        \Artisan::call('vendor:publish', [
+            '--tag' => 'medialibrary-migrations'
+        ]);
+
+        \Artisan::call('migrate');
+
+        \Artisan::call('optimize:clear');
+
         $this->info('Filament Media Manager installed successfully.');
     }
 }


### PR DESCRIPTION
At the moment `php artisan filament-media-manager:install` does not publish the Spatie media database table migration file

Replace custom artisanCommand method with direct \Artisan::call calls for better readability and maintainability. Ensure the 'vendor:publish', 'migrate', and 'optimize:clear' commands are executed directly using \Artisan.

----

- Fresh Laravel and Filament installation
- When I run `php artisan filament-media-manager:install` I get the error 

```
 Illuminate\Database\QueryException 

  SQLSTATE[HY000]: General error: 1824 Failed to open the referenced table 'media' (Connection: mysql, SQL: alter table `media_has_models` add constraint `media_has_models_media_id_foreign` foreign key (`media_id`) references `media` (`id`) on delete cascade)

  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:825
    821▕                     $this->getName(), $query, $this->prepareBindings($bindings), $e
    822▕                 );
    823▕             }
    824▕
  ➜ 825▕             throw new QueryException(
    826▕                 $this->getName(), $query, $this->prepareBindings($bindings), $e
    827▕             );
    828▕         }
    829▕     }

```




Same issue (https://github.com/tomatophp/filament-media-manager/issues/15)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the execution of commands in the application by utilizing standard Laravel methods for better clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->