### PR TITLE
Allowing the update of custom properties for MediaManagerInput

### DIFF
--- a/src/Form/MediaManagerInput.php
+++ b/src/Form/MediaManagerInput.php
@@ -31,6 +31,7 @@ use Spatie\MediaLibrary\MediaCollections\MediaCollection;
 use TomatoPHP\FilamentMediaManager\Models\Folder;
 use Closure;
 use TomatoPHP\FilamentMediaManager\Models\Media;
+use Spatie\MediaLibrary\MediaCollections\Models\Media as SpatieMedia;
 
 class MediaManagerInput extends Repeater
 {
@@ -58,6 +59,12 @@ class MediaManagerInput extends Repeater
             foreach ($setState as $item){
                 $state = array_filter(array_map(function (TemporaryUploadedFile | string $file) use ($mediaComponent, $record, $component, $item, $counter) {
                     if (! $file instanceof TemporaryUploadedFile) {
+                        $media = SpatieMedia::whereUuid($file)->first();
+                        $customProperties = collect($item)->filter(fn ($value, $key) => $key !== 'file')->toArray();
+                        foreach($customProperties as $key => $property){
+                            $media->setCustomProperty($key,$property);
+                        }
+                        $media->save();
                         return $file;
                     }
 


### PR DESCRIPTION
Right now the updating of a image doesn't change the custom properties. This change would save them if a file is already uploaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Media management has been enhanced by enabling the association of additional, customizable metadata with media items. This update allows media files to be processed and organized with improved flexibility and control, ensuring that file attributes are better managed and reflected throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->