### PR TITLE
Add error handling for media update when file is missing or invalid

### DIFF
--- a/src/Form/MediaManagerInput.php
+++ b/src/Form/MediaManagerInput.php
@@ -196,11 +196,13 @@ class MediaManagerInput extends Repeater
                 ];
                 $counter=0;
                 foreach ($items as $item){
-                    $media = Media::where('uuid', array_keys($item['file'])[0])->first();
-                    if($media){
-                        $media->update([
-                            'order_column'=> $counter
-                        ]);
+                    if (is_array($item) && isset($item['file']) && is_array($item['file']) && !empty($item['file'])) {
+                        $media = Media::where('uuid', array_keys($item['file'])[0])->first();
+                        if($media){
+                            $media->update([
+                                'order_column'=> $counter
+                            ]);
+                        }
                     }
                     $counter++;
                 }


### PR DESCRIPTION
In this fix I added error handling when I do drag n drop on the column but the image is empty/not uploaded which causes an error:
`array_keys(): Argument #1 ($array) must be of type array, null given`

The improvements I made were to add conditions such as:
```php
if (is_array($item) && isset($item['file']) && is_array($item['file']) && !empty($item['file'])) {
    $media = Media::where('uuid', array_keys($item['file'])[0])->first();
    if($media){
        $media->update([
            'order_column'=> $counter
            ]);
        }
    }
```

so around line 192 in the MediaManagerInput.php file the complete code now is:
```php
$this->reorderAction(static function (Action $action): void {
    $action->action(function (array $arguments, Repeater $component): void {
        $items = [
            ...array_flip($arguments['items']),
            ...$component->getState(),
        ];
        $counter=0;
        foreach ($items as $item){
            if (is_array($item) && isset($item['file']) && is_array($item['file']) && !empty($item['file'])) {
                $media = Media::where('uuid', array_keys($item['file'])[0])->first();
                if($media){
                    $media->update([
                        'order_column'=> $counter
                    ]);
                }
            }
            $counter++;
        }

        $component->state($items);

        $component->callAfterStateUpdated();
    });
});