### PR TITLE
feat: add custom user model config

### DIFF
--- a/config/filament-media-manager.php
+++ b/config/filament-media-manager.php
@@ -21,7 +21,8 @@ return [
     ],
 
     "user" => [
-      'column_name' => 'name', // Change the value if your field in users table is different from "name"
+        "model" => \App\Models\User::class, // Change this to your user model
+        "column_name" => "name", // Change the value if your field in users table is different from "name"
     ],
 
     "navigation_sort" => 0,

--- a/src/Models/Folder.php
+++ b/src/Models/Folder.php
@@ -2,7 +2,6 @@
 
 namespace TomatoPHP\FilamentMediaManager\Models;
 
-use App\Models\User;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
@@ -50,7 +49,7 @@ class Folder extends Model implements HasMedia
 
     public function users()
     {
-        return $this->morphedByMany(User::class, 'model', 'folder_has_models', 'folder_id', 'model_id');
+        return $this->morphedByMany(config('filament-media-manager.user.model', \App\Models\User::class), 'model', 'folder_has_models', 'folder_id', 'model_id');
     }
 
     protected static function boot()

--- a/src/Resources/Actions/EditCurrentFolderAction.php
+++ b/src/Resources/Actions/EditCurrentFolderAction.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace TomatoPHP\FilamentMediaManager\Resources\Actions;
-use App\Models\User;
+
 use Filament\Actions;
 use Filament\Forms;
 use Filament\Forms\Components\Grid;
@@ -81,7 +81,7 @@ class EditCurrentFolderAction
                                 ->label(trans('filament-media-manager::messages.folders.columns.users'))
                                 ->searchable()
                                 ->multiple()
-                                ->options(User::query()->where('id', '!=', auth()->user()->id)->pluck(config('filament-media-manager.user.column_name'), 'id')->toArray())
+                                ->options(config('filament-media-manager.user.model', \App\Models\User::class)::query()->where('id', '!=', auth()->user()->id)->pluck(config('filament-media-manager.user.column_name'), 'id')->toArray())
                         ])
                 ];
             })


### PR DESCRIPTION
This pull request introduces changes to improve the configurability of the user model in the `filament-media-manager` package. The updates allow developers to customize the user model and its associated column name through configuration, enhancing flexibility and compatibility with different project setups.

fixes #32
fixes #36

### Configuration Updates:
* Updated `config/filament-media-manager.php` to include a configurable `model` key for the user model, allowing developers to specify their custom user model class. 

### Codebase Adjustments:
* Replaced hardcoded references to `App\Models\User` with a dynamic reference to the user model defined in the configuration file in the `user()` method of `Folder.php`. 
* Removed the import of `App\Models\User` in `Folder.php` and `EditCurrentFolderAction.php`, as the user model is now dynamically resolved from the configuration. 
* Updated the `make()` method in `EditCurrentFolderAction.php` to use the configurable user model for fetching user options. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - User model class is now configurable, allowing for greater flexibility in user management.

- **Refactor**
  - Updated user-related features to dynamically use the configured user model instead of a fixed model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->