### PR TITLE
fix reverse migration folder_has_models

### DIFF
--- a/database/migrations/2024_10_03_171809_create_folder_has_models_table.php
+++ b/database/migrations/2024_10_03_171809_create_folder_has_models_table.php
@@ -34,6 +34,6 @@ return new class extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('media_has_models');
+        Schema::dropIfExists('folder_has_models');
     }
 };


### PR DESCRIPTION
renamed table name when dropping table folder_has_models

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the migration rollback process to properly remove the intended table, ensuring reliable reversal of database changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->