### PR TITLE
Replace x-icon with x-filament::icon to prevent clashes with other components called x-icon

### DIFF
--- a/resources/views/columns/media-preview.blade.php
+++ b/resources/views/columns/media-preview.blade.php
@@ -138,7 +138,7 @@
     @elseif(str($getRecord()->mime_type)->contains('video'))
         <video src="{{ $getRecord()->getUrl() }}"></video>
     @elseif(str($getRecord()->mime_type)->contains('audio'))
-        <x-icon name="heroicon-o-musical-note" class="table-media-icon-large" style="color: #ec4899;" />
+        <x-filament::icon name="heroicon-o-musical-note" class="table-media-icon-large" style="color: #ec4899;" />
     @else
         @php
             $hasPreview = false;
@@ -152,10 +152,10 @@
             }
         @endphp
         @if($hasPreview && $type)
-            <x-icon :name="$type->icon" class="table-media-icon-large" style="color: {{ $fileIcon['color'] ?? '#9ca3af' }};" />
+            <x-filament::icon :name="$type->icon" class="table-media-icon-large" style="color: {{ $fileIcon['color'] ?? '#9ca3af' }};" />
         @else
             <div class="table-media-file-icon">
-                <x-icon :name="$fileIcon['icon']" class="table-media-file-icon-image" style="color: {{ $fileIcon['color'] }};" />
+                <x-filament::icon :name="$fileIcon['icon']" class="table-media-file-icon-image" style="color: {{ $fileIcon['color'] }};" />
                 <span class="table-media-file-extension">{{ $extension }}</span>
             </div>
         @endif

--- a/resources/views/components/folder-action-view.blade.php
+++ b/resources/views/components/folder-action-view.blade.php
@@ -154,11 +154,11 @@
     <div class="folder-container-{{$item->id}}">
         <div class="folder-icon-{{$item->id}}">
             @if($item->icon)
-                <x-icon name="{{$item->icon}}" class="folder-icon-content-{{$item->id}}"/>
+                <x-filament::icon name="{{$item->icon}}" class="folder-icon-content-{{$item->id}}"/>
             @endif
             @if($item->is_protected)
                 <div class="folder-lock-badge-{{$item->id}}">
-                    <x-icon name="heroicon-o-lock-closed" class="folder-lock-icon-{{$item->id}}" />
+                    <x-filament::icon name="heroicon-o-lock-closed" class="folder-lock-icon-{{$item->id}}" />
                 </div>
             @endif
         </div>

--- a/resources/views/livewire/media-picker.blade.php
+++ b/resources/views/livewire/media-picker.blade.php
@@ -255,11 +255,11 @@
                             <div class="folder-container-picker-{{$folder->id}}">
                                 <div class="folder-icon-picker-{{$folder->id}}">
                                     @if($folder->icon)
-                                        <x-icon name="{{$folder->icon}}" class="folder-icon-content-picker-{{$folder->id}}"/>
+                                        <x-filament::icon name="{{$folder->icon}}" class="folder-icon-content-picker-{{$folder->id}}"/>
                                     @endif
                                     @if($folder->is_protected)
                                         <div class="folder-lock-badge-picker-{{$folder->id}}">
-                                            <x-icon name="heroicon-o-lock-closed" class="folder-lock-icon-picker-{{$folder->id}}" />
+                                            <x-filament::icon name="heroicon-o-lock-closed" class="folder-lock-icon-picker-{{$folder->id}}" />
                                         </div>
                                     @endif
                                 </div>
@@ -491,10 +491,10 @@
                                         @elseif(str($mediaItem->mime_type)->contains('video'))
                                             <video src="{{ $mediaItem->getUrl() }}"></video>
                                         @elseif(str($mediaItem->mime_type)->contains('audio'))
-                                            <x-icon name="heroicon-o-musical-note" class="media-icon-large-picker-{{$mediaItem->id}}" style="color: #ec4899;" />
+                                            <x-filament::icon name="heroicon-o-musical-note" class="media-icon-large-picker-{{$mediaItem->id}}" style="color: #ec4899;" />
                                         @else
                                             <div class="media-file-icon-picker-{{$mediaItem->id}}">
-                                                <x-icon :name="$fileIcon['icon']" class="media-file-icon-image-picker-{{$mediaItem->id}}" style="color: {{ $fileIcon['color'] }};" />
+                                                <x-filament::icon :name="$fileIcon['icon']" class="media-file-icon-image-picker-{{$mediaItem->id}}" style="color: {{ $fileIcon['color'] }};" />
                                                 <span class="media-file-extension-picker-{{$mediaItem->id}}">{{ $extension }}</span>
                                             </div>
                                         @endif
@@ -516,7 +516,7 @@
 
                                     @if(in_array($mediaItem->uuid, $selectedMedia))
                                         <div class="media-check-badge-picker-{{$mediaItem->id}}">
-                                            <x-icon name="heroicon-m-check" class="media-check-icon-picker-{{$mediaItem->id}}" />
+                                            <x-filament::icon name="heroicon-m-check" class="media-check-icon-picker-{{$mediaItem->id}}" />
                                         </div>
                                     @endif
                                 </div>

--- a/resources/views/pages/media.blade.php
+++ b/resources/views/pages/media.blade.php
@@ -448,7 +448,7 @@
                             @elseif(str($item->mime_type)->contains('video'))
                                 <video src="{{ $item->getUrl() }}"></video>
                             @elseif(str($item->mime_type)->contains('audio'))
-                                <x-icon name="heroicon-o-musical-note" class="media-icon-large" style="color: #ec4899;" />
+                                <x-filament::icon name="heroicon-o-musical-note" class="media-icon-large" style="color: #ec4899;" />
                             @else
                                 @php
                                     $hasPreview = false;
@@ -462,10 +462,10 @@
                                     }
                                 @endphp
                                 @if($hasPreview && $type)
-                                    <x-icon :name="$type->icon" class="media-icon-large" style="color: {{ $fileIcon['color'] ?? '#9ca3af' }};" />
+                                    <x-filament::icon :name="$type->icon" class="media-icon-large" style="color: {{ $fileIcon['color'] ?? '#9ca3af' }};" />
                                 @else
                                     <div class="media-file-icon">
-                                        <x-icon :name="$fileIcon['icon']" class="media-file-icon-image" style="color: {{ $fileIcon['color'] }};" />
+                                        <x-filament::icon :name="$fileIcon['icon']" class="media-file-icon-image" style="color: {{ $fileIcon['color'] }};" />
                                         <span class="media-file-extension">{{ $extension }}</span>
                                     </div>
                                 @endif
@@ -517,7 +517,7 @@
                                          style="max-width: 95%; max-height: 95vh; object-fit: contain; cursor: zoom-out;"
                                          @click.stop />
                                     <button @click="fullscreen = false" class="fullscreen-close-btn">
-                                        <x-icon name="heroicon-o-x-mark" style="width: 1.5rem; height: 1.5rem;" />
+                                        <x-filament::icon name="heroicon-o-x-mark" style="width: 1.5rem; height: 1.5rem;" />
                                     </button>
                                 </div>
                             </div>
@@ -532,7 +532,7 @@
                         @elseif(str($item->mime_type)->contains('audio'))
                             <div class="media-preview-link">
                                 <div class="media-file-preview-icon">
-                                    <x-icon name="heroicon-o-musical-note" class="media-file-preview-icon-large" style="color: #ec4899;" />
+                                    <x-filament::icon name="heroicon-o-musical-note" class="media-file-preview-icon-large" style="color: #ec4899;" />
                                 </div>
                                 <audio class="media-video-full" controls style="width: 100%; margin-top: 1rem;">
                                     <source src="{{ $item->getUrl() }}" type="{{ $item->mime_type }}">
@@ -555,7 +555,7 @@
                             @else
                                 <a href="{{ $item->getUrl() }}" target="_blank" class="media-preview-link">
                                     <div class="media-file-preview-icon">
-                                        <x-icon :name="$fileIcon['icon']" class="media-file-preview-icon-large" style="color: {{ $fileIcon['color'] }};" />
+                                        <x-filament::icon :name="$fileIcon['icon']" class="media-file-preview-icon-large" style="color: {{ $fileIcon['color'] }};" />
                                         <span style="font-size: 1rem; font-weight: 600; text-transform: uppercase; color: {{ $fileIcon['color'] }};">{{ $extension }}</span>
                                         <span style="font-size: 0.875rem; color: rgb(107 114 128); margin-top: 0.5rem;">Click to download</span>
                                     </div>


### PR DESCRIPTION
I am using MaryUI on my system. This has a component that uses x-icon and is causing issues. This pull replaces x-icon with x-filament::icon across the views.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated icons across media-related screens to use a unified set, improving visual consistency and clarity.
  - Affected areas include folder icons, lock badges, audio and file-type previews, selection indicators, and modal/download controls.
  - No functional changes; visuals only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->