### PR TITLE
Fix: Ensure Responsive Images are Generated on media picking for  Media Manager Picker

### DIFF
--- a/src/Form/MediaManagerPicker.php
+++ b/src/Form/MediaManagerPicker.php
@@ -6,6 +6,7 @@ use Closure;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Field;
 use Illuminate\Database\Eloquent\Model;
+use Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob;
 use TomatoPHP\FilamentMediaManager\Models\Media;
 
 class MediaManagerPicker extends Field
@@ -113,10 +114,11 @@ class MediaManagerPicker extends Field
 
             foreach ($uuids as $uuid) {
                 $mediaItem = $media->get($uuid);
+                /**@var Media $mediaItem */
                 if ($mediaItem) {
                     // Generate responsive images if enabled
-                    if ($responsiveImages && $mediaItem->hasResponsiveImages()) {
-                        $mediaItem->registerMediaConversions();
+                    if ($responsiveImages && !$mediaItem->hasResponsiveImages()) {
+                        dispatch(new GenerateResponsiveImagesJob($mediaItem));
                     }
 
                     \DB::table('media_has_models')->insert([


### PR DESCRIPTION
There is an issue that prevents Responsive Images from being generated when using the MediaManagerPicker component with the ->responsiveImages() flag enabled.

In the actual logic in TomatoPHP\FilamentMediaManager\Form\MediaManagerPicker.php:
- The code check for $mediaItem->hasResponsiveImages() before attempting to generate them. A newly uploaded media item will never have responsive images yet, meaning the entire generation block was skipped.
- The original code called $mediaItem->registerMediaConversions(). This method does not exist.

This pr updates the logic in if condition and uses Spatie's GenerateResponsiveImagesJob to dispatch a job to generate responsive image for media if the media doesnt have responsive images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced responsive image generation to process images asynchronously when responsive images are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->