### PR TITLE
feat: make user ID column configurable

### DIFF
--- a/config/filament-media-manager.php
+++ b/config/filament-media-manager.php
@@ -23,6 +23,7 @@ return [
     'user' => [
         'model' => \App\Models\User::class, // Change this to your user model
         'column_name' => 'name', // Change the value if your field in users table is different from "name"
+     'id_column' => 'id', // Add this line
     ],
 
     'navigation_sort' => 0,

--- a/src/Resources/Actions/EditCurrentFolderAction.php
+++ b/src/Resources/Actions/EditCurrentFolderAction.php
@@ -83,7 +83,7 @@ class EditCurrentFolderAction
                                 ->searchable()
                                 ->multiple()
                                // Replace it  ->options(config('filament-media-manager.user.model', \App\Models\User::class)::query()->where('id', '!=', auth()->user()->id)->pluck(config('filament-media-manager.user.column_name'), 'id')->toArray()), with:
-                                ->options(function () {
+                                  ->options(function () {
                                     $userModel = config('filament-media-manager.user.model', \App\Models\User::class);
                                     $columnName = config('filament-media-manager.user.column_name', 'name');
                                     $idColumn = config('filament-media-manager.user.id_column', 'id');

--- a/src/Resources/Actions/EditCurrentFolderAction.php
+++ b/src/Resources/Actions/EditCurrentFolderAction.php
@@ -82,7 +82,17 @@ class EditCurrentFolderAction
                                 ->label(trans('filament-media-manager::messages.folders.columns.users'))
                                 ->searchable()
                                 ->multiple()
-                                ->options(config('filament-media-manager.user.model', \App\Models\User::class)::query()->where('id', '!=', auth()->user()->id)->pluck(config('filament-media-manager.user.column_name'), 'id')->toArray()),
+                               // Replace it  ->options(config('filament-media-manager.user.model', \App\Models\User::class)::query()->where('id', '!=', auth()->user()->id)->pluck(config('filament-media-manager.user.column_name'), 'id')->toArray()), with:
+                                ->options(function () {
+                                    $userModel = config('filament-media-manager.user.model', \App\Models\User::class);
+                                    $columnName = config('filament-media-manager.user.column_name', 'name');
+                                    $idColumn = config('filament-media-manager.user.id_column', 'id');
+                                    
+                                    return $userModel::query()
+                                        ->where($idColumn, '!=', auth()->id())
+                                        ->pluck($columnName, $idColumn)
+                                        ->toArray();
+                                }),
                         ]),
                 ];
             })


### PR DESCRIPTION
## Description
This PR adds configuration support for the user ID column name, making the plugin more flexible for different database schemas.

## Changes
- Added `id_column` configuration option in user config
- Updated `EditCurrentFolderAction` to use configurable ID column
- Fixed hardcoded 'id' column references

## Problem
Currently, the plugin assumes the user table has an `id` column, which breaks in applications using different primary key names like `user_id`, `uuid`, etc.

## Solution
Make the ID column configurable via `config('filament-media-manager.user.id_column', 'id')`

## Testing
Tested with both `id` and `user_id` column names.

## Configuration
Users can now add to their config:
```php
'user' => [
    'model' => \App\Models\User::class,
    'column_name' => 'name',
    'id_column' => 'user_id', // or 'id', 'uuid', etc.
],

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * User identifier column is now configurable in settings, allowing customization based on your database schema
  * User selection in folder management actions now dynamically retrieves options, providing more flexibility and supporting custom user model configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->